### PR TITLE
Delay booting plugin until WordPress calls the `init` hook

### DIFF
--- a/equal-height-columns.php
+++ b/equal-height-columns.php
@@ -65,4 +65,11 @@ function run_equal_height_columns() {
 	$plugin->run();
 
 }
-run_equal_height_columns();
+
+// Delay running until WordPress is ready
+add_action(
+    'init',
+    static function () {
+        run_equal_height_columns();
+    },
+);

--- a/equal-height-columns.php
+++ b/equal-height-columns.php
@@ -9,7 +9,7 @@
  * @wordpress-plugin
  * Plugin Name:       Equal Height Columns
  * Description:       Apply equal heights to uneven columns and elements.
- * Version:           1.2.1
+ * Version:           1.2.2
  * Author:            MIGHTYminnow, Mickey Kay, Braad Martin
  * Author URI:        http://mightyminnow.com
  * License:           GPL-2.0+

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Tags:**              equal, height, column, div, element, jQuery, JavaScript  
 **Requires at least:** 3.5  
 **Tested up to:**      6.7.1
-**Stable tag:**        1.2.1  
+**Stable tag:**        1.2.2  
 **License:**           GPLv2 or later  
 **License URI:**       http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -155,6 +155,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 1. Activate Equal Height Columns through the 'Plugins' menu in WordPress.
 
 ## Changelog ##
+
+### 1.2.2 ###
+* BUGFIX: Notice: Function _load_textdomain_just_in_time was called incorrectly.
 
 ### 1.2.1 ###
 * BUGFIX: Manual call to .initEqualHeights() was not working with recent jQuery versions.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://mightyminnow.com
 Tags: equal, height, column, div, element, jQuery, JavaScript
 Requires at least: 3.5
 Tested up to: 6.7.1
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -155,6 +155,9 @@ You can report security bugs through the Patchstack Vulnerability Disclosure Pro
 1. Activate Equal Height Columns through the 'Plugins' menu in WordPress.
 
 == Changelog ==
+
+### 1.2.2 ###
+* BUGFIX: Notice: Function _load_textdomain_just_in_time was called incorrectly.
 
 ### 1.2.1 ###
 * BUGFIX: Manual call to .initEqualHeights() was not working with recent jQuery versions.


### PR DESCRIPTION
Address https://github.com/MIGHTYminnow/equal-height-columns/issues/6